### PR TITLE
removed vue from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "passport": "^0.3.2",
     "passport-jwt": "^2.2.1",
     "source-map-support": "^0.4.15",
-    "vue": "^2.4.2",
     "vuex": "^2.3.1",
     "whatwg-fetch": "^2.0.3"
   },

--- a/store/index.js
+++ b/store/index.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line
 import Vue from 'vue';
 import Vuex from 'vuex';
 


### PR DESCRIPTION
Fixed error of mismatched versions (https://github.com/derekshull/nuxt-starter-kit/issues/1) by removing vue from package.json.  Nuxt has vue included so there is no need to have it in package.json.